### PR TITLE
primarily refactored for a more functional approach. Also refactored …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.2</version>
+		<version>2.5.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.jpr</groupId>
@@ -15,6 +15,10 @@
 	<description>motor cycle maintenance api</description>
 	<properties>
 		<java.version>11</java.version>
+		<graphql-java.version>17.2</graphql-java.version>
+		<graphql-java-spring-boot-starter-webmvc.version>2.0</graphql-java-spring-boot-starter-webmvc.version>
+		<lombok.version>1.18.20</lombok.version>
+		<vavr.version>0.10.4</vavr.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -24,12 +28,12 @@
 		<dependency>
 			<groupId>com.graphql-java</groupId>
 			<artifactId>graphql-java</artifactId>
-			<version>17.0</version>
+			<version>${graphql-java.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.graphql-java</groupId>
 			<artifactId>graphql-java-spring-boot-starter-webmvc</artifactId>
-			<version>2.0</version>
+			<version>${graphql-java-spring-boot-starter-webmvc.version}</version>
 		</dependency>
 
 		<dependency>
@@ -45,13 +49,13 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.20</version>
+			<version>${lombok.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.vavr</groupId>
 			<artifactId>vavr</artifactId>
-			<version>0.10.4</version>
+			<version>${vavr.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/jpr/maintenance/database/model/TaskDetailsEntity.java
+++ b/src/main/java/com/jpr/maintenance/database/model/TaskDetailsEntity.java
@@ -2,6 +2,8 @@ package com.jpr.maintenance.database.model;
 
 import com.jpr.maintenance.validation.model.taskdetails.TaskDetails;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -9,6 +11,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+@ToString
+@NoArgsConstructor
 @Entity
 @Table(name = "task_details")
 @Getter
@@ -20,8 +24,6 @@ public class TaskDetailsEntity {
     private String description;
     private Integer interval_km;
     private Integer interval_months;
-
-    public TaskDetailsEntity() {}
 
     private TaskDetailsEntity(String description, Integer interval_km, Integer interval_months) {
         this.description = description;

--- a/src/main/java/com/jpr/maintenance/database/model/TaskDetailsEntity.java
+++ b/src/main/java/com/jpr/maintenance/database/model/TaskDetailsEntity.java
@@ -1,6 +1,7 @@
 package com.jpr.maintenance.database.model;
 
 import com.jpr.maintenance.validation.model.taskdetails.TaskDetails;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -11,6 +12,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+@EqualsAndHashCode
 @ToString
 @NoArgsConstructor
 @Entity

--- a/src/main/java/com/jpr/maintenance/database/service/TaskDetailsService.java
+++ b/src/main/java/com/jpr/maintenance/database/service/TaskDetailsService.java
@@ -2,10 +2,12 @@ package com.jpr.maintenance.database.service;
 
 import com.jpr.maintenance.database.model.TaskDetailsEntity;
 import com.jpr.maintenance.database.repository.TaskDetailsRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
+@Slf4j
 @Component
 public class TaskDetailsService { // TODO better name than ...service ?
 
@@ -20,7 +22,9 @@ public class TaskDetailsService { // TODO better name than ...service ?
     }
 
     public TaskDetailsEntity save(TaskDetailsEntity taskDetails) {
-        return repository.save(taskDetails);
+        TaskDetailsEntity entity = repository.save(taskDetails);
+        log.info(entity.toString());
+        return entity;
     }
 
     public void deleteById(Integer id) {

--- a/src/main/java/com/jpr/maintenance/graphql/DataFetcherWrapper.java
+++ b/src/main/java/com/jpr/maintenance/graphql/DataFetcherWrapper.java
@@ -1,0 +1,13 @@
+package com.jpr.maintenance.graphql;
+
+import graphql.schema.DataFetcher;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DataFetcherWrapper<T> {
+    private final String parentType;
+    private final String fieldName;
+    private final DataFetcher<T> dataFetcher;
+}

--- a/src/main/java/com/jpr/maintenance/graphql/GraphQLDataFetchers.java
+++ b/src/main/java/com/jpr/maintenance/graphql/GraphQLDataFetchers.java
@@ -22,27 +22,27 @@ public class GraphQLDataFetchers {
     @Bean
     public DataFetcherWrapper<TaskDetailsEntity> getTaskDetailsById() {
         return new DataFetcherWrapper<>(
-                "Query",
-                "taskDetailsById",
-                dataFetchingEnvironment -> {
-                    String taskId = dataFetchingEnvironment.getArgument("task_id");
-                    return service.findById(Integer.valueOf(taskId)).stream().findFirst().orElse(null);
-                }
+            "Query",
+            "taskDetailsById",
+            dataFetchingEnvironment -> {
+                String taskId = dataFetchingEnvironment.getArgument("task_id");
+                return service.findById(Integer.valueOf(taskId)).stream().findFirst().orElse(null);
+            }
         );
     }
 
     @Bean
     public DataFetcherWrapper<DataFetcherResult<TaskDetailsEntity>> createTaskDetails() {
         return new DataFetcherWrapper<>(
-                "Mutation",
-                "createTaskDetails",
-                dataFetchingEnvironment ->
-                        TaskDetails.of(dataFetchingEnvironment)
-                                .flatMap(t -> saveTaskDetails(t, dataFetchingEnvironment))
-                                .fold(
-                                        errorFun(),
-                                        successFun()
-                                )
+            "Mutation",
+            "createTaskDetails",
+            dataFetchingEnvironment ->
+                TaskDetails.of(dataFetchingEnvironment)
+                    .flatMap(t -> saveTaskDetails(t, dataFetchingEnvironment))
+                    .fold(
+                        errorFun(),
+                        successFun()
+                    )
         );
     }
 
@@ -54,13 +54,13 @@ public class GraphQLDataFetchers {
     @Bean
     public DataFetcherWrapper<Void> deleteTaskDetails() {
         return new DataFetcherWrapper<>(
-                "Mutation",
-                "deleteTaskDetails",
-                dataFetchingEnvironment -> {
-                    String task_id = dataFetchingEnvironment.getArgument("task_id");
-                    service.deleteById(Integer.valueOf(task_id));
-                    return null;
-                }
+            "Mutation",
+            "deleteTaskDetails",
+            dataFetchingEnvironment -> {
+                String task_id = dataFetchingEnvironment.getArgument("task_id");
+                service.deleteById(Integer.valueOf(task_id));
+                return null;
+            }
         );
     }
 }

--- a/src/main/java/com/jpr/maintenance/graphql/GraphQLDataFetchers.java
+++ b/src/main/java/com/jpr/maintenance/graphql/GraphQLDataFetchers.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import static com.jpr.maintenance.graphql.GraphQLUtils.saveEntity;
+import static com.jpr.maintenance.graphql.GraphQLUtils.*;
 
 @RequiredArgsConstructor
 @Configuration
@@ -40,8 +40,8 @@ public class GraphQLDataFetchers {
                         TaskDetails.of(dataFetchingEnvironment)
                                 .flatMap(t -> saveTaskDetails(t, dataFetchingEnvironment))
                                 .fold(
-                                        l -> DataFetcherResult.<TaskDetailsEntity>newResult().error(l).build(),
-                                        r -> DataFetcherResult.<TaskDetailsEntity>newResult().data(r).build()
+                                        errorFun(),
+                                        successFun()
                                 )
         );
     }

--- a/src/main/java/com/jpr/maintenance/graphql/GraphQLDataFetchers.java
+++ b/src/main/java/com/jpr/maintenance/graphql/GraphQLDataFetchers.java
@@ -2,57 +2,65 @@ package com.jpr.maintenance.graphql;
 
 import com.jpr.maintenance.database.model.TaskDetailsEntity;
 import com.jpr.maintenance.database.service.TaskDetailsService;
-import com.jpr.maintenance.validation.errors.InputValidationError;
 import com.jpr.maintenance.validation.model.taskdetails.TaskDetails;
+import graphql.GraphQLError;
 import graphql.execution.DataFetcherResult;
-import graphql.schema.DataFetcher;
-import org.springframework.stereotype.Component;
+import graphql.schema.DataFetchingEnvironment;
+import io.vavr.control.Either;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-import java.util.function.Consumer;
+import static com.jpr.maintenance.graphql.GraphQLUtils.saveEntity;
 
-@Component
+@RequiredArgsConstructor
+@Configuration
 public class GraphQLDataFetchers {
-
     private final TaskDetailsService service;
 
-    public GraphQLDataFetchers(TaskDetailsService service) {
-        this.service = service;
+    //TODO refactor to return DataFetcherResult
+    @Bean
+    public DataFetcherWrapper<TaskDetailsEntity> getTaskDetailsById() {
+        return new DataFetcherWrapper<>(
+                "Query",
+                "taskDetailsById",
+                dataFetchingEnvironment -> {
+                    String taskId = dataFetchingEnvironment.getArgument("task_id");
+                    return service.findById(Integer.valueOf(taskId)).stream().findFirst().orElse(null);
+                }
+        );
+    }
+
+    @Bean
+    public DataFetcherWrapper<DataFetcherResult<TaskDetailsEntity>> createTaskDetails() {
+        return new DataFetcherWrapper<>(
+                "Mutation",
+                "createTaskDetails",
+                dataFetchingEnvironment ->
+                        TaskDetails.of(dataFetchingEnvironment)
+                                .flatMap(t -> saveTaskDetails(t, dataFetchingEnvironment))
+                                .fold(
+                                        l -> DataFetcherResult.<TaskDetailsEntity>newResult().error(l).build(),
+                                        r -> DataFetcherResult.<TaskDetailsEntity>newResult().data(r).build()
+                                )
+        );
+    }
+
+    private Either<GraphQLError, TaskDetailsEntity> saveTaskDetails(TaskDetails taskDetails, DataFetchingEnvironment environment) {
+        return saveEntity(TaskDetailsEntity.of(taskDetails), service::save, environment);
     }
 
     //TODO refactor to return DataFetcherResult
-    public DataFetcher<TaskDetailsEntity> getTaskDetailsById() {
-        return dataFetchingEnvironment -> {
-            String taskId = dataFetchingEnvironment.getArgument("task_id");
-            return service.findById(Integer.valueOf(taskId)).stream().findFirst().orElse(null);
-        };
-    }
-
-    public DataFetcher<DataFetcherResult<TaskDetails>> createTaskDetails() {
-        return dataFetchingEnvironment -> {
-            DataFetcherResult.Builder<TaskDetails> resultBuilder = DataFetcherResult.newResult();
-            TaskDetails.of(dataFetchingEnvironment)
-                .peekLeft(handleErrors())
-                .peek(details -> {
-                    service.save(TaskDetailsEntity.of(details));
-                    resultBuilder.data(details);
-                });
-            return resultBuilder.build();
-        };
-    }
-
-    // TODO move error handling to its own class
-    private Consumer<InputValidationError> handleErrors() {
-        return error -> {
-            System.out.println(error.name());
-        };
-    }
-
-    //TODO refactor to return DataFetcherResult
-    public DataFetcher<Void> deleteTaskDetails() {
-        return dataFetchingEnvironment -> {
-            String task_id = dataFetchingEnvironment.getArgument("task_id");
-            service.deleteById(Integer.valueOf(task_id));
-            return null;
-        };
+    @Bean
+    public DataFetcherWrapper<Void> deleteTaskDetails() {
+        return new DataFetcherWrapper<>(
+                "Mutation",
+                "deleteTaskDetails",
+                dataFetchingEnvironment -> {
+                    String task_id = dataFetchingEnvironment.getArgument("task_id");
+                    service.deleteById(Integer.valueOf(task_id));
+                    return null;
+                }
+        );
     }
 }

--- a/src/main/java/com/jpr/maintenance/graphql/GraphQLProvider.java
+++ b/src/main/java/com/jpr/maintenance/graphql/GraphQLProvider.java
@@ -22,14 +22,14 @@ import static graphql.schema.idl.TypeRuntimeWiring.newTypeWiring;
 @Configuration
 public class GraphQLProvider {
     @Bean
-    public GraphQL graphQL(@Autowired GraphQLSchema schema) {
+    public GraphQL graphQL(GraphQLSchema schema) {
         return GraphQL
-                .newGraphQL(schema)
-                .build();
+            .newGraphQL(schema)
+            .build();
     }
 
     @Bean
-    public GraphQLSchema buildSchema(@Autowired RuntimeWiring runtimeWiring) throws IOException {
+    public GraphQLSchema buildSchema(RuntimeWiring runtimeWiring) throws IOException {
         ClassPathResource resource = new ClassPathResource("schema.graphqls");
         String sdl = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
         TypeDefinitionRegistry typeRegistry = new SchemaParser().parse(sdl);
@@ -38,25 +38,24 @@ public class GraphQLProvider {
     }
 
     @Bean
-    public RuntimeWiring buildDataFetcherWiring(@Autowired List<DataFetcherWrapper<?>> dataFetcherWrappers) {
+    public RuntimeWiring buildDataFetcherWiring(List<DataFetcherWrapper<?>> dataFetcherWrappers) {
         return buildDataFetcherWiringRecursively(
-                RuntimeWiring.newRuntimeWiring(),
-                io.vavr.collection.List.ofAll(dataFetcherWrappers)
+            RuntimeWiring.newRuntimeWiring(),
+            io.vavr.collection.List.ofAll(dataFetcherWrappers)
         ).invoke();
     }
 
-    private TailCall<RuntimeWiring> buildDataFetcherWiringRecursively(
-            RuntimeWiring.Builder runtimeWiringBuilder,
-            io.vavr.collection.List<DataFetcherWrapper<?>> vavrList) {
+    private TailCall<RuntimeWiring> buildDataFetcherWiringRecursively(RuntimeWiring.Builder runtimeWiringBuilder,
+                                                                      io.vavr.collection.List<DataFetcherWrapper<?>> vavrList) {
         if (vavrList.isEmpty()) {
             return done(runtimeWiringBuilder.build());
         } else {
             DataFetcherWrapper<?> wrapper = vavrList.head();
             return () -> buildDataFetcherWiringRecursively(
-                    runtimeWiringBuilder
-                            .type(newTypeWiring(wrapper.getParentType())
-                                    .dataFetcher(wrapper.getFieldName(), wrapper.getDataFetcher())),
-                    vavrList.tail()
+                runtimeWiringBuilder
+                    .type(newTypeWiring(wrapper.getParentType())
+                        .dataFetcher(wrapper.getFieldName(), wrapper.getDataFetcher())),
+                vavrList.tail()
             );
         }
     }

--- a/src/main/java/com/jpr/maintenance/graphql/GraphQLUtils.java
+++ b/src/main/java/com/jpr/maintenance/graphql/GraphQLUtils.java
@@ -1,0 +1,26 @@
+package com.jpr.maintenance.graphql;
+
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
+import graphql.schema.DataFetchingEnvironment;
+import io.vavr.control.Either;
+import org.springframework.dao.DataAccessException;
+
+import java.util.function.Function;
+
+import static com.jpr.maintenance.validation.errors.InputValidationError.DATA_PERSISTENCE_ERROR;
+
+public class GraphQLUtils {
+    public static <T> Either<GraphQLError, T> saveEntity(T entity, Function<T, T> persistenceFun, DataFetchingEnvironment environment) {
+        try {
+            return Either.right(persistenceFun.apply(entity));
+        } catch (DataAccessException e) {
+            return Either.left(
+                    GraphqlErrorBuilder
+                            .newError(environment)
+                            .errorType(DATA_PERSISTENCE_ERROR)
+                            .build()
+            );
+        }
+    }
+}

--- a/src/main/java/com/jpr/maintenance/graphql/GraphQLUtils.java
+++ b/src/main/java/com/jpr/maintenance/graphql/GraphQLUtils.java
@@ -2,6 +2,7 @@ package com.jpr.maintenance.graphql;
 
 import graphql.GraphQLError;
 import graphql.GraphqlErrorBuilder;
+import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetchingEnvironment;
 import io.vavr.control.Either;
 import org.springframework.dao.DataAccessException;
@@ -22,5 +23,13 @@ public class GraphQLUtils {
                             .build()
             );
         }
+    }
+
+    public static <T> Function<T, DataFetcherResult<T>> successFun() {
+        return r -> DataFetcherResult.<T>newResult().data(r).build();
+    }
+
+    public static <T> Function<GraphQLError, DataFetcherResult<T>> errorFun() {
+        return l -> DataFetcherResult.<T>newResult().error(l).build();
     }
 }

--- a/src/main/java/com/jpr/maintenance/graphql/GraphQLUtils.java
+++ b/src/main/java/com/jpr/maintenance/graphql/GraphQLUtils.java
@@ -17,10 +17,10 @@ public class GraphQLUtils {
             return Either.right(persistenceFun.apply(entity));
         } catch (DataAccessException e) {
             return Either.left(
-                    GraphqlErrorBuilder
-                            .newError(environment)
-                            .errorType(DATA_PERSISTENCE_ERROR)
-                            .build()
+                GraphqlErrorBuilder
+                    .newError(environment)
+                    .errorType(DATA_PERSISTENCE_ERROR)
+                    .build()
             );
         }
     }

--- a/src/main/java/com/jpr/maintenance/tailrecursion/TailCall.java
+++ b/src/main/java/com/jpr/maintenance/tailrecursion/TailCall.java
@@ -9,14 +9,16 @@ public interface TailCall<T> {
     default boolean isComplete() {
         return false;
     }
+
     default T result() {
         throw new Error("not implemented");
     }
+
     default T invoke() {
         return Stream.iterate(this, TailCall::apply)
-                .filter(TailCall::isComplete)
-                .findFirst()
-                .get()
-                .result();
+            .filter(TailCall::isComplete)
+            .findFirst()
+            .get()
+            .result();
     }
 }

--- a/src/main/java/com/jpr/maintenance/tailrecursion/TailCall.java
+++ b/src/main/java/com/jpr/maintenance/tailrecursion/TailCall.java
@@ -1,0 +1,22 @@
+package com.jpr.maintenance.tailrecursion;
+
+import java.util.stream.Stream;
+
+@FunctionalInterface
+public interface TailCall<T> {
+    TailCall<T> apply();
+
+    default boolean isComplete() {
+        return false;
+    }
+    default T result() {
+        throw new Error("not implemented");
+    }
+    default T invoke() {
+        return Stream.iterate(this, TailCall::apply)
+                .filter(TailCall::isComplete)
+                .findFirst()
+                .get()
+                .result();
+    }
+}

--- a/src/main/java/com/jpr/maintenance/tailrecursion/TailCalls.java
+++ b/src/main/java/com/jpr/maintenance/tailrecursion/TailCalls.java
@@ -1,0 +1,22 @@
+package com.jpr.maintenance.tailrecursion;
+
+public class TailCalls {
+    public static <T> TailCall<T> done(final T value) {
+        return new TailCall<T>() {
+            @Override
+            public boolean isComplete() {
+                return true;
+            }
+
+            @Override
+            public T result() {
+                return value;
+            }
+
+            @Override
+            public TailCall apply() {
+                throw new Error("not implemented");
+            }
+        };
+    }
+}

--- a/src/main/java/com/jpr/maintenance/validation/errors/InputValidationError.java
+++ b/src/main/java/com/jpr/maintenance/validation/errors/InputValidationError.java
@@ -1,6 +1,8 @@
 package com.jpr.maintenance.validation.errors;
 
-public enum InputValidationError {
+import graphql.ErrorClassification;
 
-    INVALID_DESCRIPTION;
+public enum InputValidationError implements ErrorClassification {
+
+    INVALID_DESCRIPTION, DATA_PERSISTENCE_ERROR;
 }

--- a/src/main/java/com/jpr/maintenance/validation/model/taskdetails/TaskDetails.java
+++ b/src/main/java/com/jpr/maintenance/validation/model/taskdetails/TaskDetails.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.regex.Pattern;
+
 @RequiredArgsConstructor
 @Getter
 public class TaskDetails {
@@ -24,10 +25,10 @@ public class TaskDetails {
         final String description = environment.getArgument("description");
         if (!descriptionWhitelist.matcher(description).matches()) {
             return Either.left(
-                    GraphqlErrorBuilder.newError()
-                            .errorType(InputValidationError.INVALID_DESCRIPTION)
-                            .message("The description must consist of only letters and spaces, between 1 and 100 characters long.")
-                            .build()
+                GraphqlErrorBuilder.newError()
+                    .errorType(InputValidationError.INVALID_DESCRIPTION)
+                    .message("The description must consist of only letters and spaces, between 1 and 100 characters long.")
+                    .build()
             );
         }
         Integer interval_km = environment.getArgument("interval_km");

--- a/src/main/java/com/jpr/maintenance/validation/model/taskdetails/TaskDetails.java
+++ b/src/main/java/com/jpr/maintenance/validation/model/taskdetails/TaskDetails.java
@@ -1,12 +1,15 @@
 package com.jpr.maintenance.validation.model.taskdetails;
 
 import com.jpr.maintenance.validation.errors.InputValidationError;
+import graphql.GraphQLError;
+import graphql.GraphqlErrorBuilder;
 import graphql.schema.DataFetchingEnvironment;
 import io.vavr.control.Either;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.regex.Pattern;
-
+@RequiredArgsConstructor
 @Getter
 public class TaskDetails {
 
@@ -17,16 +20,15 @@ public class TaskDetails {
     private final Integer interval_km;
     private final Integer interval_months;
 
-    private TaskDetails(String description, Integer interval_km, Integer interval_months) {
-        this.description = description;
-        this.interval_km = interval_km;
-        this.interval_months = interval_months;
-    }
-
-    public static Either<InputValidationError, TaskDetails> of(DataFetchingEnvironment environment) {
+    public static Either<GraphQLError, TaskDetails> of(DataFetchingEnvironment environment) {
         final String description = environment.getArgument("description");
         if (!descriptionWhitelist.matcher(description).matches()) {
-            return Either.left(InputValidationError.INVALID_DESCRIPTION);
+            return Either.left(
+                    GraphqlErrorBuilder.newError()
+                            .errorType(InputValidationError.INVALID_DESCRIPTION)
+                            .message("The description must consist of only letters and spaces, between 1 and 100 characters long.")
+                            .build()
+            );
         }
         Integer interval_km = environment.getArgument("interval_km");
         Integer interval_months = environment.getArgument("interval_months");
@@ -36,5 +38,4 @@ public class TaskDetails {
             interval_months
         ));
     }
-
 }

--- a/src/test/java/com/jpr/maintenance/graphql/GraphQLDataFetchersTest.java
+++ b/src/test/java/com/jpr/maintenance/graphql/GraphQLDataFetchersTest.java
@@ -4,7 +4,6 @@ import com.jpr.maintenance.database.model.TaskDetailsEntity;
 import com.jpr.maintenance.database.repository.TaskDetailsRepository;
 import com.jpr.maintenance.database.service.TaskDetailsService;
 import com.jpr.maintenance.database.testing.TaskDetailsRepositoryTestImpl;
-import com.jpr.maintenance.validation.model.taskdetails.TaskDetails;
 import graphql.execution.DataFetcherResult;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironmentImpl;
@@ -12,10 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class GraphQLDataFetchersTest {
 

--- a/src/test/java/com/jpr/maintenance/graphql/GraphQLDataFetchersTest.java
+++ b/src/test/java/com/jpr/maintenance/graphql/GraphQLDataFetchersTest.java
@@ -29,7 +29,7 @@ class GraphQLDataFetchersTest {
         var environment = new DataFetchingEnvironmentImpl.Builder()
             .arguments(arguments)
             .build();
-        DataFetcher<TaskDetailsEntity> dataFetcher = graphQLDataFetchers.getTaskDetailsById();
+        DataFetcher<TaskDetailsEntity> dataFetcher = graphQLDataFetchers.getTaskDetailsById().getDataFetcher();
         TaskDetailsEntity taskDetails = dataFetcher.get(environment);
 
         assertNotNull(taskDetails);
@@ -41,7 +41,7 @@ class GraphQLDataFetchersTest {
         var environment = new DataFetchingEnvironmentImpl.Builder()
             .arguments(arguments)
             .build();
-        DataFetcher<TaskDetailsEntity> dataFetcher = graphQLDataFetchers.getTaskDetailsById();
+        DataFetcher<TaskDetailsEntity> dataFetcher = graphQLDataFetchers.getTaskDetailsById().getDataFetcher();
         TaskDetailsEntity taskDetails = dataFetcher.get(environment);
 
         assertNull(taskDetails);
@@ -57,9 +57,9 @@ class GraphQLDataFetchersTest {
         var environment = new DataFetchingEnvironmentImpl.Builder()
             .arguments(arguments)
             .build();
-        DataFetcher<DataFetcherResult<TaskDetails>> dataFetcher = graphQLDataFetchers.createTaskDetails();
-        DataFetcherResult<TaskDetails> dataFetcherResult = dataFetcher.get(environment);
-        TaskDetails resultData = dataFetcherResult.getData();
+        DataFetcher<DataFetcherResult<TaskDetailsEntity>> dataFetcher = graphQLDataFetchers.createTaskDetails().getDataFetcher();
+        DataFetcherResult<TaskDetailsEntity> dataFetcherResult = dataFetcher.get(environment);
+        TaskDetailsEntity resultData = dataFetcherResult.getData();
 
         assertEquals("description", resultData.getDescription());
         assertEquals(5000, resultData.getInterval_km());
@@ -75,8 +75,8 @@ class GraphQLDataFetchersTest {
         var environment = new DataFetchingEnvironmentImpl.Builder()
             .arguments(arguments)
             .build();
-        DataFetcher<DataFetcherResult<TaskDetails>> dataFetcher = graphQLDataFetchers.createTaskDetails();
-        DataFetcherResult<TaskDetails> dataFetcherResult = dataFetcher.get(environment);
+        DataFetcher<DataFetcherResult<TaskDetailsEntity>> dataFetcher = graphQLDataFetchers.createTaskDetails().getDataFetcher();
+        DataFetcherResult<TaskDetailsEntity> dataFetcherResult = dataFetcher.get(environment);
 
         assertNull(dataFetcherResult.getData());
     }
@@ -87,7 +87,7 @@ class GraphQLDataFetchersTest {
         var environment = new DataFetchingEnvironmentImpl.Builder()
             .arguments(arguments)
             .build();
-        DataFetcher<Void> dataFetcher = graphQLDataFetchers.deleteTaskDetails();
+        DataFetcher<Void> dataFetcher = graphQLDataFetchers.deleteTaskDetails().getDataFetcher();
         Void unused = dataFetcher.get(environment);
 
         assertNull(unused);

--- a/src/test/java/com/jpr/maintenance/validation/model/taskdetails/TaskDetailsTest.java
+++ b/src/test/java/com/jpr/maintenance/validation/model/taskdetails/TaskDetailsTest.java
@@ -1,6 +1,5 @@
 package com.jpr.maintenance.validation.model.taskdetails;
 
-import com.jpr.maintenance.validation.errors.InputValidationError;
 import graphql.GraphQLError;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import io.vavr.control.Either;

--- a/src/test/java/com/jpr/maintenance/validation/model/taskdetails/TaskDetailsTest.java
+++ b/src/test/java/com/jpr/maintenance/validation/model/taskdetails/TaskDetailsTest.java
@@ -1,6 +1,7 @@
 package com.jpr.maintenance.validation.model.taskdetails;
 
 import com.jpr.maintenance.validation.errors.InputValidationError;
+import graphql.GraphQLError;
 import graphql.schema.DataFetchingEnvironmentImpl;
 import io.vavr.control.Either;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ class TaskDetailsTest {
         var environment = new DataFetchingEnvironmentImpl.Builder()
             .arguments(arguments)
             .build();
-        Either<InputValidationError, TaskDetails> taskDetailsEither = TaskDetails.of(environment);
+        Either<GraphQLError, TaskDetails> taskDetailsEither = TaskDetails.of(environment);
 
         assertTrue(taskDetailsEither.isRight());
         TaskDetails taskDetails = taskDetailsEither.get();
@@ -43,10 +44,10 @@ class TaskDetailsTest {
         var environment = new DataFetchingEnvironmentImpl.Builder()
             .arguments(arguments)
             .build();
-        Either<InputValidationError, TaskDetails> taskDetailsEither = TaskDetails.of(environment);
+        Either<GraphQLError, TaskDetails> taskDetailsEither = TaskDetails.of(environment);
 
         assertTrue(taskDetailsEither.isLeft());
-        assertEquals(INVALID_DESCRIPTION, taskDetailsEither.getLeft());
+        assertEquals(INVALID_DESCRIPTION, taskDetailsEither.getLeft().getErrorType());
     }
 
     @Test
@@ -59,10 +60,10 @@ class TaskDetailsTest {
         var environment = new DataFetchingEnvironmentImpl.Builder()
             .arguments(arguments)
             .build();
-        Either<InputValidationError, TaskDetails> taskDetailsEither = TaskDetails.of(environment);
+        Either<GraphQLError, TaskDetails> taskDetailsEither = TaskDetails.of(environment);
 
         assertTrue(taskDetailsEither.isLeft());
-        assertEquals(INVALID_DESCRIPTION, taskDetailsEither.getLeft());
+        assertEquals(INVALID_DESCRIPTION, taskDetailsEither.getLeft().getErrorType());
     }
 
     @Test
@@ -75,9 +76,9 @@ class TaskDetailsTest {
         var environment = new DataFetchingEnvironmentImpl.Builder()
             .arguments(arguments)
             .build();
-        Either<InputValidationError, TaskDetails> taskDetailsEither = TaskDetails.of(environment);
+        Either<GraphQLError, TaskDetails> taskDetailsEither = TaskDetails.of(environment);
 
         assertTrue(taskDetailsEither.isLeft());
-        assertEquals(INVALID_DESCRIPTION, taskDetailsEither.getLeft());
+        assertEquals(INVALID_DESCRIPTION, taskDetailsEither.getLeft().getErrorType());
     }
 }


### PR DESCRIPTION
…the datafetchers to always return a TaskDetailsEntity. I'm not sure yet if that is the correct approach but at least now it's consistent whereas previously the taskDetailsById would return an entity and the create function would return a TaskDetails. Perhaps they should all be TaskDetails as usually you don't want to return a DTO type and not directly the entity but let's discuss. I will put the database access change proposal in a separate PR.